### PR TITLE
Fix glaring post-launch errors

### DIFF
--- a/content/project/color-themes.md
+++ b/content/project/color-themes.md
@@ -5,9 +5,24 @@ client: "Squarespace"
 weight: 2
 gallery:
   - src: "color-panels"
+    alt: "controls offering curated and generated color palettes"
+    caption: >
+      We developed a range of curated starting points and generative color tools 
+      to help users zero in on a brand identity regardless of skill level
   - src: "color-annotations"
+    alt: "a yaml spec and corresponding UI for website color themes"
+    caption: >
+      I wrote an initial spec to map the design intent of color theming
+      onto the existing Squarespace styling framework
   - src: "color-sections"
-  - src: "theme-tool"
+    alt: "a pale red color theme applied to a Squarespace website"
+    caption: >
+      The color tools generate a range of themes, which can be applied to individual page sections
+  - src: "color-theme-tool"
+    alt: "screenshot of an interactive tool to check color combinations for accessiblity"
+    caption: >
+      To assist designers in creating curated color palettes, I wrote this theme checking tool
+      that verifies themes generated from the color palette result in accessible color combinations
 ---
 
 To address user feedback requesting more creative flexibility, I worked with a small team to prototype a color theming system. We needed to balance Squarespace’s characteristic ease of use with tools to make more varied, expressive websites.

--- a/content/project/equinox-training.md
+++ b/content/project/equinox-training.md
@@ -1,5 +1,5 @@
 ---
-title: "Equinox Training"
+title: "Personal Training"
 date: 2022
 client: "Equinox"
 weight: 4

--- a/layouts/partials/head/favicon.html
+++ b/layouts/partials/head/favicon.html
@@ -1,3 +1,9 @@
-<link rel="icon" href="/icon.svg" type="image/svg+xml">
-<link rel="mask-icon" href="/icon.svg" color="#0e0e0e">
-<link rel="mask-icon" href="/icon.svg" color="#fafafa" media="(prefers-color-scheme: dark)">
+{{ if hugo.IsProduction }}
+	<link rel="icon" href="/icon.svg" type="image/svg+xml">
+	<link rel="mask-icon" href="/icon.svg" color="#0e0e0e">
+	<link rel="mask-icon" href="/icon.svg" color="#fafafa" media="(prefers-color-scheme: dark)">
+{{ else }}
+	<link 
+		rel="icon" 
+		href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🛠</text></svg>">
+{{ end }}


### PR DESCRIPTION
it is an iron law of the universe that as soon as a piece of software
is published several obvious errors will come to light.

* add alt and captions to Color Themes case study
* add a different favicon in development
* reword the equinox title so there isn't duplication
